### PR TITLE
snapcraft: use date based version for now

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@ name: core16
 version: 16-2
 version-script: |
     # remember to keep version script in sync with "Makefile"
-    echo "16-$(cat prime/usr/lib/snapd/info |cut -f2 -d=| sed s/~ubuntu.*// | cut -b1-29)"
+    echo "16-$(date date +%Y%m%d)"
 summary: core16 runtime environment
 description: The core16 runtime environment
 confinement: strict


### PR DESCRIPTION
The current core16 is very much a developer version so it seems
fine to append the date to the version for now. We will need to
come up with a smarter version schema later but this should be
okay for now.