### PR TITLE
Handle PPAs being served from ppa.launchpadcontent.net

### DIFF
--- a/live-build/hooks/02-check-package-env.chroot
+++ b/live-build/hooks/02-check-package-env.chroot
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 
 echo "Ensure the project is build with the ppa:snappy-dev/image PPA"
-if ! apt-cache policy ubuntu-core-config|grep ppa.launchpad.net/snappy-dev/image; then
+if ! apt-cache policy ubuntu-core-config|grep -E 'ppa\.launchpad(content)?\.net/snappy-dev/image'; then
     echo "The ppa:snappy-dev/image PPA is missing."
     echo "This probably means that the build was triggered incorrectly."
     apt-cache policy ubuntu-core-config


### PR DESCRIPTION
We now have a new HTTPS-capable domain for public PPAs, namely
ppa.launchpadcontent.net.  Adjust the build system to accept that.